### PR TITLE
handle empty auth command

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -123,10 +123,39 @@ func authCmd(ctx context.Context, cmd *AuthCmd, overrideAuthURL string, logWrite
 		err = signup(ctx, client, u, p)
 	case cmd.Logout != nil:
 		logout()
+		pterm.Info.Println("Logged out, goodbye!")
+	default:
+		askForAuthSubCmd(cmd)
+		authCmd(ctx, cmd, overrideAuthURL, logWriter)
 	}
 
 	if err != nil {
 		pterm.Error.Printfln("Error authenticating: %s", err.Error())
+		os.Exit(2)
+	}
+}
+
+// askForAuthSubCmd handles an empty "auth" command, requiring selection of a subcommand
+func askForAuthSubCmd(cmd *AuthCmd) {
+	options := []string{"login", "signup", "logout"}
+	selector := pterm.DefaultInteractiveSelect.WithOptions(options)
+	selection, err := pterm.InteractiveSelectPrinter.WithOptions(*selector, options).Show("Select auth action")
+	if err != nil {
+		pterm.Error.Println("Error reading command")
+		os.Exit(2)
+	}
+	switch selection {
+	case "login":
+		args.Auth.Login = &LoginCmd{}
+		return
+	case "signup":
+		args.Auth.Signup = &SignupCmd{}
+		return
+	case "logout":
+		args.Auth.Logout = &LogoutCmd{}
+		return
+	default:
+		pterm.Error.Println("Invalid auth subcommand")
 		os.Exit(2)
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -294,7 +294,7 @@ github.com/getlantern/fdcount v0.0.0-20210503151800-5decd65b3731/go.mod h1:XZwE+
 github.com/getlantern/filepersist v0.0.0-20160317154340-c5f0cd24e799/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c h1:mcz27xtAkb1OuOLBct/uFfL1p3XxAIcFct82GbT+UZM=
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
-github.com/getlantern/flashlight/v7 v7.6.188 h1:U/CjpuTxz6ZaawlrrJQ+V1rsjYWhUU9CKCURbOy5Q7o=
+github.com/getlantern/flashlight/v7 v7.6.188 h1:5UBbq2NxkODAAxEIBFGscA5Jrdft5BgIDua7LYld4Pk=
 github.com/getlantern/flashlight/v7 v7.6.188/go.mod h1:Q4/N6vraoxLNrTJhYuFXTrGkk8vIzEmGdkKY3GywQO8=
 github.com/getlantern/fronted v0.0.0-20250205182429-f8aa4896e1e5 h1:Epy63dEBOiy1y+4B0TpIlDA9s/IaVth+Iy4/QlVj8Iw=
 github.com/getlantern/fronted v0.0.0-20250205182429-f8aa4896e1e5/go.mod h1:/4g6lEMXHzkF/6WBr3vod4wh3tos632qSZGh7L/fIdg=


### PR DESCRIPTION

## prior behavior
Passing an empty "auth" command with no subcommand does nothing and exits `0`.

That might lead some to believe that auth was successful or that they were already logged in, rather than being aware they passed an invalid command.

## changes
prompt for subcommand when not provided

## comparison

<img width="755" alt="Screenshot 2025-02-07 at 13 34 02" src="https://github.com/user-attachments/assets/c5cfed4b-8ece-421e-ad3f-709336f9b99f" />
